### PR TITLE
Bump to Go 1.26

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,7 @@ platforms: &platforms
   - arm64
 
 alpine: &alpine
+  - "3.20"
   - "3.21"
   - "3.22"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,8 @@
 ARG alpine_version=3.21
-FROM golang:1.26.0-alpine${alpine_version} as build
+FROM alpine:${alpine_version} AS build
 
-RUN apk add make \
+RUN apk add curl \
+            make \
             cmake \
             gcc \
             g++ \
@@ -9,6 +10,21 @@ RUN apk add make \
             wv \
             lynx \
             tesseract-ocr-dev
+
+# Install Go manually. That way we are not tied to a specific version of Go + Alpine.
+# @todo, Update this to buildx in a future release.
+ARG go_version=1.26.0
+RUN set -eux; \
+    arch="$(apk --print-arch)"; \
+    case "$arch" in \
+      x86_64) goarch="amd64" ;; \
+      aarch64) goarch="arm64" ;; \
+      *) echo "unsupported arch: $arch" && exit 1 ;; \
+    esac; \
+    curl -fsSL https://go.dev/dl/go${go_version}.linux-${goarch}.tar.gz \
+      | tar -C /usr/local -xz
+
+ENV PATH="/usr/local/go/bin:${PATH}"
 
 WORKDIR /go/src/code.sajari.com/docconv
 COPY . /go/src/code.sajari.com/docconv

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 ARG alpine_version=3.21
-FROM golang:1.25.5-alpine${alpine_version} as build
+FROM golang:1.26.0-alpine${alpine_version} as build
 
 RUN apk add make \
             cmake \

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module code.sajari.com/docconv
 
-go 1.25.5
+go 1.26.0
 
 require (
 	github.com/JalfResi/justext v0.0.0-20221106200834-be571e3e3052


### PR DESCRIPTION
## Overview

Updates to Go 1.26 as a part of security updates.

https://previousnext.atlassian.net/browse/SKPR-1141
